### PR TITLE
use Integer.parseInt instead of Integer.valueOf

### DIFF
--- a/src/main/java/jp/co/dwango/logback/SlackWebhookAppender.java
+++ b/src/main/java/jp/co/dwango/logback/SlackWebhookAppender.java
@@ -100,7 +100,7 @@ public class SlackWebhookAppender extends UnsynchronizedAppenderBase<ILoggingEve
      * @param timeout timeout
      */
     public void setTimeout(String timeout) {
-        this.timeout = Integer.valueOf(timeout);
+        this.timeout = Integer.parseInt(timeout);
     }
 
     /**


### PR DESCRIPTION
avoid unnecessary unboxing

`Integer.parseInt` return primitive `int`.
`Integer.valueOf` return `java.lang.Integer`

- https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html#parseInt-java.lang.String-
- https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html#valueOf-java.lang.String-