### PR TITLE
Cancel posting if it returns null

### DIFF
--- a/src/main/java/jp/co/dwango/logback/SlackWebhookAppender.java
+++ b/src/main/java/jp/co/dwango/logback/SlackWebhookAppender.java
@@ -228,6 +228,9 @@ public class SlackWebhookAppender extends UnsynchronizedAppenderBase<ILoggingEve
         try {
             Invocable invocable = (Invocable)engine;
             Object payload = invocable.invokeFunction("payload", eventObject);
+            if(payload == null) {
+                return;
+            }
 
             Object JSON = engine.get("JSON");
             Object payloadStr = invocable.invokeMethod(JSON, "stringify", payload);

--- a/src/test/java/jp/co/dwango/logback/SlackWebhookAppenderTest.java
+++ b/src/test/java/jp/co/dwango/logback/SlackWebhookAppenderTest.java
@@ -63,6 +63,34 @@ public class SlackWebhookAppenderTest {
         String expected = "{\"channel\":\"#channel\",\"username\":\"username\",\"icon_emoji\":\":white_circle:\",\"link_names\":1,\"attachments\":[{\"title\":\"title - test.local\",\"color\":\"good\",\"fields\":[{\"title\":\"Message\",\"value\":\"text \\\"quoted\\\"\",\"short\":false}]}]}";
         Assert.assertEquals(expected, actual);
     }
+    
+    /**
+     * Test canceling post when returning null 
+     */
+    @Test
+    public void testCancelPost() {
+        byte[] body = "expect unchanging".getBytes();
+        
+        AppenderForTest appender = new AppenderForTest();
+        appender.body = body;
+        appender.setWebhookUrl("https://hooks.slack.com/services/ABCDEF/GHIJK/LMNOPQR");
+        appender.setPayload(
+            "return null;");
+        appender.start();
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONTEXT_NAME", "textContext");
+        properties.put("HOSTNAME", "test.local");
+        
+        LoggingEvent event = new LoggingEvent();
+        event.setLevel(Level.INFO);
+        event.setMessage("text \"quoted\"");
+        event.setLoggerContextRemoteView(new LoggerContextVO("test", properties, 123L));
+        
+        appender.append(event);
+        
+        Assert.assertArrayEquals(body, appender.body);
+    }
 
     @Ignore
     public void testPost() {


### PR DESCRIPTION
- If payload function returns null, cancel the posting.
- Prevent posting unintended content.
Currently, "null" will be posted if it returns null.